### PR TITLE
Fix duplicate build target in Makefile

### DIFF
--- a/MAKEFILE
+++ b/MAKEFILE
@@ -1,11 +1,17 @@
-build:
-	echo 'test'
-
 gazelle:
 	bazel run //:gazelle
 
 build:
 	bazel build //...
 
+test:
+	bazel test //...
+
+clean:
+	bazel clean
+
 run-helloworld:
 	bazel build //packages/helloworld && bazel run //packages/helloworld
+
+run-service1:
+	bazel build //services/service1 && bazel run //services/service1


### PR DESCRIPTION
## Summary
- Removed the duplicate `build:` target (the first one just ran `echo 'test'`, shadowing the real build target)
- Added `test` target (`bazel test //...`)
- Added `clean` target (`bazel clean`)
- Added `run-service1` target for running the service1 binary

## Test plan
- [ ] Run `make build` and verify it runs `bazel build //...`
- [ ] Run `make test` and verify it runs `bazel test //...`
- [ ] Run `make clean` and verify it cleans bazel artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)