### PR TITLE
Update Go version in SETUP.md to 1.26.0

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -2,7 +2,7 @@
 
 This repo needs the following to be installed
 
-- Go 1.24.0 `brew install go`
+- Go 1.26.0 `brew install go`
 - Bazelisk 7.3.1 `brew install bazelisk`
   - Note that Bazelisk has Bazel included, so you don't have to install Bazel separately
 - Go tools `go get golang.org/x/tools`


### PR DESCRIPTION
## Summary
- Updated Go version reference from 1.24.0 to 1.26.0 to match the current `go.mod`

## Test plan
- [ ] Verify SETUP.md shows the correct Go version

🤖 Generated with [Claude Code](https://claude.com/claude-code)