### PR TITLE
Improve humanize_filesize API with int64 and auto-scaling units

### DIFF
--- a/libraries/humanize_filesize/humanize_filesize.go
+++ b/libraries/humanize_filesize/humanize_filesize.go
@@ -2,11 +2,23 @@ package humanize_filesize
 
 import "fmt"
 
-// GetHumanizedFilesize takes size_in_bytes as an int32 pointer and returns the size in megabytes.
-func GetHumanizedFilesize(size_in_bytes *int32) string {
-	if size_in_bytes != nil {
-		size_in_megabytes := float64(*size_in_bytes) / (1024 * 1024)
-		return fmt.Sprintf("%.4f MB", size_in_megabytes)
+// HumanizeFilesize takes a size in bytes and returns a human-readable string
+// with an appropriate unit (B, KB, MB, GB, TB).
+func HumanizeFilesize(sizeInBytes int64) string {
+	if sizeInBytes < 0 {
+		return "0 B"
 	}
-	return "0 MB"
+
+	switch {
+	case sizeInBytes >= 1<<40:
+		return fmt.Sprintf("%.2f TB", float64(sizeInBytes)/float64(1<<40))
+	case sizeInBytes >= 1<<30:
+		return fmt.Sprintf("%.2f GB", float64(sizeInBytes)/float64(1<<30))
+	case sizeInBytes >= 1<<20:
+		return fmt.Sprintf("%.2f MB", float64(sizeInBytes)/float64(1<<20))
+	case sizeInBytes >= 1<<10:
+		return fmt.Sprintf("%.2f KB", float64(sizeInBytes)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", sizeInBytes)
+	}
 }

--- a/libraries/humanize_filesize/humanize_filesize_test.go
+++ b/libraries/humanize_filesize/humanize_filesize_test.go
@@ -6,37 +6,53 @@ import (
 
 func TestHumanizeFilesize(t *testing.T) {
 	tests := []struct {
-		name          string
-		size_in_bytes *int32
-		expected      string
+		name        string
+		sizeInBytes int64
+		expected    string
 	}{
 		{
-			name:          "nil bytes",
-			size_in_bytes: nil,
-			expected:      "0 MB",
+			name:        "zero bytes",
+			sizeInBytes: 0,
+			expected:    "0 B",
 		},
 		{
-			name:          "2048 bytes",
-			size_in_bytes: int32Ptr(2048),
-			expected:      "0.0020 MB",
+			name:        "negative bytes",
+			sizeInBytes: -1,
+			expected:    "0 B",
 		},
 		{
-			name:          "0 bytes",
-			size_in_bytes: int32Ptr(0),
-			expected:      "0.0000 MB",
+			name:        "500 bytes",
+			sizeInBytes: 500,
+			expected:    "500 B",
+		},
+		{
+			name:        "2048 bytes",
+			sizeInBytes: 2048,
+			expected:    "2.00 KB",
+		},
+		{
+			name:        "1 MB",
+			sizeInBytes: 1048576,
+			expected:    "1.00 MB",
+		},
+		{
+			name:        "1.5 GB",
+			sizeInBytes: 1610612736,
+			expected:    "1.50 GB",
+		},
+		{
+			name:        "2 TB",
+			sizeInBytes: 2199023255552,
+			expected:    "2.00 TB",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetHumanizedFilesize(tt.size_in_bytes)
+			result := HumanizeFilesize(tt.sizeInBytes)
 			if result != tt.expected {
-				t.Errorf("expected %s, got %s", tt.expected, result)
+				t.Errorf("HumanizeFilesize(%d) = %s, want %s", tt.sizeInBytes, result, tt.expected)
 			}
 		})
 	}
-}
-
-func int32Ptr(n int32) *int32 {
-	return &n
 }

--- a/services/service1/service1.go
+++ b/services/service1/service1.go
@@ -8,6 +8,6 @@ import (
 )
 
 func main() {
-	v := rand.Int31n(1000000)
-	fmt.Printf(`%d bytes = %s`, v, humanize_filesize.GetHumanizedFilesize(&v))
+	v := rand.Int63n(1000000)
+	fmt.Printf("%d bytes = %s\n", v, humanize_filesize.HumanizeFilesize(v))
 }


### PR DESCRIPTION
## Summary
- Changed parameter from `*int32` to `int64` for idiomatic Go and support for large files
- Auto-scales output to the appropriate unit (B, KB, MB, GB, TB) instead of always showing MB
- Renamed function to `HumanizeFilesize` (dropped "Get" prefix per Go conventions)
- Updated service1 to use the new API
- Expanded test coverage with cases for all unit scales

## Test plan
- [x] `bazel test //...` passes
- [ ] Verify output formatting for each unit scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)