### PR TITLE
Use structured logging (log/slog) in service1

### DIFF
--- a/services/service1/service1.go
+++ b/services/service1/service1.go
@@ -1,13 +1,21 @@
 package main
 
 import (
-	"fmt"
+	"log/slog"
 	"math/rand"
+	"os"
 
 	"github.com/nikhildev/basil/libraries/humanize_filesize"
 )
 
 func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
 	v := rand.Int31n(1000000)
-	fmt.Printf(`%d bytes = %s`, v, humanize_filesize.GetHumanizedFilesize(&v))
+	humanized := humanize_filesize.GetHumanizedFilesize(&v)
+
+	logger.Info("generated random filesize",
+		"bytes", v,
+		"humanized", humanized,
+	)
 }


### PR DESCRIPTION
## Summary
- Replaced `fmt.Printf` with `log/slog` for structured, leveled logging
- Demonstrates production-ready logging patterns using Go's stdlib (available since Go 1.21)

## Test plan
- [ ] Run `bazel run //services/service1` and verify structured log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)