### PR TITLE
Add tests for service1 and helloworld packages

### DIFF
--- a/packages/helloworld/BUILD.bazel
+++ b/packages/helloworld/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(
     name = "helloworld",
@@ -12,4 +12,10 @@ go_library(
     srcs = ["helloworld.go"],
     importpath = "github.com/nikhildev/basil/packages/helloworld",
     visibility = ["//visibility:private"],
+)
+
+go_test(
+    name = "helloworld_test",
+    srcs = ["helloworld_test.go"],
+    embed = [":helloworld_lib"],
 )

--- a/packages/helloworld/helloworld_test.go
+++ b/packages/helloworld/helloworld_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestMainOutput(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	main()
+
+	w.Close()
+	os.Stdout = old
+
+	out, _ := io.ReadAll(r)
+	got := string(out)
+	want := "Hello World!\n"
+	if got != want {
+		t.Errorf("main() output = %q, want %q", got, want)
+	}
+}

--- a/services/service1/BUILD.bazel
+++ b/services/service1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(
     name = "service1",
@@ -12,4 +12,10 @@ go_library(
     importpath = "github.com/nikhildev/basil/services/service1",
     visibility = ["//visibility:private"],
     deps = ["//libraries/humanize_filesize"],
+)
+
+go_test(
+    name = "service1_test",
+    srcs = ["service1_test.go"],
+    embed = [":service1_lib"],
 )

--- a/services/service1/service1.go
+++ b/services/service1/service1.go
@@ -7,7 +7,11 @@ import (
 	"github.com/nikhildev/basil/libraries/humanize_filesize"
 )
 
+func formatSize(v int32) string {
+	return fmt.Sprintf("%d bytes = %s", v, humanize_filesize.GetHumanizedFilesize(&v))
+}
+
 func main() {
 	v := rand.Int31n(1000000)
-	fmt.Printf(`%d bytes = %s`, v, humanize_filesize.GetHumanizedFilesize(&v))
+	fmt.Print(formatSize(v))
 }

--- a/services/service1/service1_test.go
+++ b/services/service1/service1_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       int32
+		wantPrefix  string
+		wantContain string
+	}{
+		{
+			name:        "zero bytes",
+			input:       0,
+			wantPrefix:  "0 bytes = ",
+			wantContain: "MB",
+		},
+		{
+			name:        "2048 bytes",
+			input:       2048,
+			wantPrefix:  "2048 bytes = ",
+			wantContain: "MB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatSize(tt.input)
+			if !strings.HasPrefix(result, tt.wantPrefix) {
+				t.Errorf("formatSize(%d) = %q, want prefix %q", tt.input, result, tt.wantPrefix)
+			}
+			if !strings.Contains(result, tt.wantContain) {
+				t.Errorf("formatSize(%d) = %q, want to contain %q", tt.input, result, tt.wantContain)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extracted testable `formatSize` function in service1
- Added table-driven tests for service1's `formatSize`
- Added stdout-capture test for helloworld's main output
- Updated BUILD.bazel files with `go_test` targets
- Test count goes from 1 to 3 targets

## Test plan
- [x] `bazel test //...` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)