### PR TITLE
Add golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - ineffassign
+    - gofmt
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/nikhildev/basil


### PR DESCRIPTION
## Summary
- Added `.golangci.yml` with standard linters enabled: errcheck, govet, staticcheck, unused, ineffassign, gofmt, goimports
- Configured local import prefix for the monorepo (`github.com/nikhildev/basil`)

## Test plan
- [ ] Install golangci-lint and run `golangci-lint run ./...`
- [ ] Verify no false positives on current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)