### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      - id: go-vet
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict


### PR DESCRIPTION
## Summary
- Added `.pre-commit-config.yaml` with hooks for:
  - `go-fmt` — enforce standard Go formatting
  - `go-imports` — enforce import ordering
  - `go-vet` — catch common Go mistakes
  - `trailing-whitespace` / `end-of-file-fixer` — file hygiene
  - `check-yaml` / `check-merge-conflict` — prevent common errors

## Test plan
- [ ] Install pre-commit: `pip install pre-commit && pre-commit install`
- [ ] Verify hooks run on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)