### PR TITLE
Add error handling to humanize_filesize library

### DIFF
--- a/libraries/humanize_filesize/humanize_filesize.go
+++ b/libraries/humanize_filesize/humanize_filesize.go
@@ -1,12 +1,21 @@
 package humanize_filesize
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrNegativeSize = errors.New("size cannot be negative")
 
 // GetHumanizedFilesize takes size_in_bytes as an int32 pointer and returns the size in megabytes.
-func GetHumanizedFilesize(size_in_bytes *int32) string {
-	if size_in_bytes != nil {
-		size_in_megabytes := float64(*size_in_bytes) / (1024 * 1024)
-		return fmt.Sprintf("%.4f MB", size_in_megabytes)
+// Returns an error if the pointer is nil or the value is negative.
+func GetHumanizedFilesize(size_in_bytes *int32) (string, error) {
+	if size_in_bytes == nil {
+		return "", errors.New("size_in_bytes must not be nil")
 	}
-	return "0 MB"
+	if *size_in_bytes < 0 {
+		return "", ErrNegativeSize
+	}
+	size_in_megabytes := float64(*size_in_bytes) / (1024 * 1024)
+	return fmt.Sprintf("%.4f MB", size_in_megabytes), nil
 }

--- a/libraries/humanize_filesize/humanize_filesize_test.go
+++ b/libraries/humanize_filesize/humanize_filesize_test.go
@@ -1,19 +1,26 @@
 package humanize_filesize
 
 import (
+	"errors"
 	"testing"
 )
 
-func TestHumanizeFilesize(t *testing.T) {
+func TestGetHumanizedFilesize(t *testing.T) {
 	tests := []struct {
 		name          string
 		size_in_bytes *int32
 		expected      string
+		wantErr       bool
 	}{
 		{
-			name:          "nil bytes",
+			name:          "nil bytes returns error",
 			size_in_bytes: nil,
-			expected:      "0 MB",
+			wantErr:       true,
+		},
+		{
+			name:          "negative bytes returns error",
+			size_in_bytes: int32Ptr(-1),
+			wantErr:       true,
 		},
 		{
 			name:          "2048 bytes",
@@ -29,11 +36,29 @@ func TestHumanizeFilesize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetHumanizedFilesize(tt.size_in_bytes)
+			result, err := GetHumanizedFilesize(tt.size_in_bytes)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestErrNegativeSize(t *testing.T) {
+	v := int32Ptr(-100)
+	_, err := GetHumanizedFilesize(v)
+	if !errors.Is(err, ErrNegativeSize) {
+		t.Errorf("expected ErrNegativeSize, got %v", err)
 	}
 }
 

--- a/services/service1/service1.go
+++ b/services/service1/service1.go
@@ -3,11 +3,17 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"os"
 
 	"github.com/nikhildev/basil/libraries/humanize_filesize"
 )
 
 func main() {
 	v := rand.Int31n(1000000)
-	fmt.Printf(`%d bytes = %s`, v, humanize_filesize.GetHumanizedFilesize(&v))
+	humanized, err := humanize_filesize.GetHumanizedFilesize(&v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%d bytes = %s\n", v, humanized)
 }


### PR DESCRIPTION
## Summary
- Changed `GetHumanizedFilesize` to return `(string, error)` instead of just `string`
- Added `ErrNegativeSize` sentinel error for negative input values
- Returns error for nil pointer input instead of silently returning "0 MB"
- Updated service1 to demonstrate proper error handling with stderr and non-zero exit
- Added test cases for nil and negative error paths

## Test plan
- [x] `bazel test //...` passes
- [ ] Run `bazel run //services/service1` and verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)